### PR TITLE
Remove aliases related to Python3.

### DIFF
--- a/runcoms/zshrc
+++ b/runcoms/zshrc
@@ -21,11 +21,6 @@ zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'
 # Vim
 alias vi="nvim"
 
-# Python
-alias python='python3'
-alias pip='pip3'
-alias pydoc='pydoc3'
-
 # Android
 export ANDROID_SDK_ROOT=`brew --prefix`/share/android-sdk
 


### PR DESCRIPTION
This prevents the access to Python2 virtual environment.